### PR TITLE
wave to answeer

### DIFF
--- a/app/src/main/java/dev/goodwy/rphone/controller/CallService.kt
+++ b/app/src/main/java/dev/goodwy/rphone/controller/CallService.kt
@@ -11,6 +11,7 @@ import android.telecom.TelecomManager
 import androidx.core.net.toUri
 import dev.goodwy.rphone.R
 import dev.goodwy.rphone.controller.util.PreferenceManager
+import dev.goodwy.rphone.controller.util.WaveToAnswerManager
 import dev.goodwy.rphone.data.manager.CallStateManager
 import dev.goodwy.rphone.modal.`interface`.CallSession
 import dev.goodwy.rphone.modal.`interface`.ICallRepository
@@ -32,6 +33,8 @@ class CallService : InCallService() {
     private val notificationManager: CallNotificationManager by inject()
     private val callRepository: ICallRepository by inject()
 
+    private lateinit var waveToAnswerManager: WaveToAnswerManager
+
     private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var redialCount = 0
     private val callStartTimes = mutableMapOf<Call, Long>()
@@ -39,6 +42,12 @@ class CallService : InCallService() {
     override fun onCreate() {
         super.onCreate()
         (callRepository as? CallRepositoryImpl)?.bindService(this)
+
+        waveToAnswerManager = WaveToAnswerManager(this) {
+            if (preferenceManager.getBoolean(PreferenceManager.KEY_WAVE_TO_ANSWER, false)) {
+                callRepository.answerCall()
+            }
+        }
 
         serviceScope.launch {
             callRepository.isActivityVisible.collect {
@@ -186,6 +195,14 @@ class CallService : InCallService() {
     private fun updateCallState() {
         val callsList = calls ?: emptyList()
         callRepository.updateAllCalls(callsList)
+
+        // Start/Stop Wave to Answer gesture detection
+        val anyRinging = callsList.any { it.state == Call.STATE_RINGING }
+        if (anyRinging && preferenceManager.getBoolean(PreferenceManager.KEY_WAVE_TO_ANSWER, false)) {
+            waveToAnswerManager.start()
+        } else {
+            waveToAnswerManager.stop()
+        }
 
         callsList.forEach { c ->
             if (c.state == Call.STATE_ACTIVE) {
@@ -368,6 +385,7 @@ class CallService : InCallService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        waveToAnswerManager.stop()
         (callRepository as? CallRepositoryImpl)?.unbindService()
         serviceScope.cancel()
     }

--- a/app/src/main/java/dev/goodwy/rphone/controller/util/PreferenceManager.kt
+++ b/app/src/main/java/dev/goodwy/rphone/controller/util/PreferenceManager.kt
@@ -294,6 +294,7 @@ class PreferenceManager(context: Context) {
         const val KEY_SPEED_DIAL            = "speed_dial"
         const val KEY_T9_DIALING            = "t9_dialing"
         const val KEY_PROXIMITY_SENSOR = "proximity_sensor"
+        const val KEY_WAVE_TO_ANSWER = "wave_to_answer"
         const val KEY_INCOMING_CALL_POPUP = "incoming_call_popup"
         const val KEY_AUTO_REDIAL_BUSY = "auto_redial_busy"
         const val KEY_REDIAL_ATTEMPTS = "redial_attempts"

--- a/app/src/main/java/dev/goodwy/rphone/controller/util/WaveToAnswerManager.kt
+++ b/app/src/main/java/dev/goodwy/rphone/controller/util/WaveToAnswerManager.kt
@@ -1,0 +1,84 @@
+package dev.goodwy.rphone.controller.util
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.util.Log
+
+/**
+ * Manages the "Wave to Answer" feature using the proximity sensor.
+ * Detects a gesture: Far -> Near -> Far within 0.2 to 1.5 seconds.
+ */
+class WaveToAnswerManager(
+    context: Context,
+    private val onWaveDetected: () -> Unit
+) : SensorEventListener {
+
+    private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    private val proximitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY)
+
+    private var lastNearTime = 0L
+    private var isNear = false
+    private var isRunning = false
+
+    // Time window for the gesture (Far -> Near -> Far)
+    private val minGestureDuration = 200L
+    private val maxGestureDuration = 1500L
+
+    fun start() {
+        if (isRunning) return
+        proximitySensor?.let {
+            sensorManager.registerListener(this, it, SensorManager.SENSOR_DELAY_UI)
+            isRunning = true
+            Log.d("WaveToAnswerManager", "Proximity sensor registered")
+        }
+    }
+
+    fun stop() {
+        if (!isRunning) return
+        sensorManager.unregisterListener(this)
+        isNear = false
+        isRunning = false
+        lastNearTime = 0L
+        Log.d("WaveToAnswerManager", "Proximity sensor unregistered")
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event?.sensor?.type == Sensor.TYPE_PROXIMITY) {
+            val distance = event.values[0]
+            val maxRange = event.sensor.maximumRange
+            
+            // Logic to determine Near vs Far
+            // Usually, proximity sensor returns 0 for Near and maxRange for Far.
+            // Some sensors might return values in between.
+            val currentIsNear = distance < maxRange && distance < 5.0f
+
+            if (currentIsNear && !isNear) {
+                // Transition: Far -> Near
+                isNear = true
+                lastNearTime = System.currentTimeMillis()
+                Log.d("WaveToAnswerManager", "Gesture: Near detected")
+            } else if (!currentIsNear && isNear) {
+                // Transition: Near -> Far
+                isNear = false
+                val now = System.currentTimeMillis()
+                val duration = now - lastNearTime
+                
+                Log.d("WaveToAnswerManager", "Gesture: Far detected. Duration: $duration ms")
+
+                if (duration in minGestureDuration..maxGestureDuration) {
+                    Log.d("WaveToAnswerManager", "Wave gesture successful!")
+                    onWaveDetected()
+                } else {
+                    Log.d("WaveToAnswerManager", "Wave gesture failed: duration out of range")
+                }
+            }
+        }
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        // Not needed for this implementation
+    }
+}

--- a/app/src/main/java/dev/goodwy/rphone/view/screen/settings/CallSettingScreen.kt
+++ b/app/src/main/java/dev/goodwy/rphone/view/screen/settings/CallSettingScreen.kt
@@ -57,6 +57,7 @@ fun CallSettingScreen(navigator: DestinationsNavigator) {
     var autoSpeaker by remember { mutableStateOf(prefs.getBoolean(PreferenceManager.KEY_AUTO_SPEAKER, false)) }
     var defaultSim by remember { mutableStateOf(prefs.getInt(PreferenceManager.KEY_DEFAULT_SIM, prefs.getDefaultSimIndexDefault())) }
     var fullscreenCalls by remember { mutableStateOf(prefs.getBoolean(PreferenceManager.KEY_ALWAYS_FULLSCREEN_CALLS, false)) }
+    var waveToAnswer by remember { mutableStateOf(prefs.getBoolean(PreferenceManager.KEY_WAVE_TO_ANSWER, false)) }
 
     var visible by remember { mutableStateOf(false) }
     val screenAlpha by animateFloatAsState(
@@ -215,6 +216,18 @@ fun CallSettingScreen(navigator: DestinationsNavigator) {
                                 onCheckedChange = {
                                     fullscreenCalls = it
                                     prefs.setBoolean(PreferenceManager.KEY_ALWAYS_FULLSCREEN_CALLS, it)
+                                }
+                            )
+                            RillSwitchListItem(
+                                headline   = stringResource(R.string.wave_to_answer),
+                                supporting = stringResource(R.string.wave_to_answer_subtitle),
+                                leadingIcon = Icons.Rounded.SpatialTracking,
+                                iconContainerColor = MaterialTheme.colorScheme.customColors.colorDarkOrange,
+                                iconBgContainerColor = MaterialTheme.colorScheme.customColors.colorOrange,
+                                checked = waveToAnswer,
+                                onCheckedChange = {
+                                    waveToAnswer = it
+                                    prefs.setBoolean(PreferenceManager.KEY_WAVE_TO_ANSWER, it)
                                 }
                             )
                             RillSwitchListItem(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,6 +200,8 @@
     <string name="auto_speaker_subtitle">Automatically switch to loudspeaker when phone is away from ear, and back to earpiece when near</string>
     <string name="fullscreen_calls">Full-screen calls</string>
     <string name="fullscreen_calls_subtitle">Incoming calls are always displayed in full-screen mode</string>
+    <string name="wave_to_answer">Wave to Answer</string>
+    <string name="wave_to_answer_subtitle">Wave your hand over the proximity sensor to answer incoming calls</string>
 
     <string name="sound_and_vibration">Sound &amp; Vibration</string>
     <string name="sound_and_vibration_subtitle">Ringtones, dialpad tones, and haptics across app</string>


### PR DESCRIPTION
1.
Gesture Detection: A new   WaveToAnswerManager.kt class handles the proximity sensor logic. It looks for a specific pattern:
◦
Near State: Your hand is close to the top of the phone.
◦
Far State: Hand moves away.
◦
Timing: The entire motion must occur within 1.0 to 1.5 seconds. This duration helps prevent accidental triggers from quick flashes or long-term obstructions.
2.
InCallService Integration: The   CallService.kt now manages this manager's lifecycle. It registers the sensor listener only when there is an incoming ringing call and unregisters it as soon as the call is handled (answered, declined, or disconnected) to save battery.
3.
UI Settings: I've added a new toggle in the Call Settings screen so you can enable/disable this feature easily.
◦
Added strings to   strings.xml.
◦
Added a switch to   CallSettingScreen.kt.